### PR TITLE
📝 docs: update skill install paths with category subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ description: A clear description of what this skill does and when to use it
 ### Claude Code
 ```bash
 # Install a skill from this repo
-claude skill install isandrel/skills/skills/[skill-name]
+claude skill install isandrel/skills/skills/[category]/[skill-name]
 ```
 
 ### openskills (Cross-platform)
 ```bash
 # Install for any agent that supports openskills
-openskills install isandrel/skills/skills/[skill-name]
+openskills install isandrel/skills/skills/[category]/[skill-name]
 ```
 
 ## Resources


### PR DESCRIPTION
Update installation command examples in README to include `[category]` in the path to reflect the new organized skills structure.

## Changes
- Updated Claude Code install example path
- Updated openskills install example path