### PR TITLE
✨ feat(tooling): add skill-manager for multi-agent skill installation

### DIFF
--- a/skills/tooling/skill-manager/SKILL.md
+++ b/skills/tooling/skill-manager/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: skill-manager
+description: |
+  Manage AI agent skills across multiple platforms. Detects installed agents,
+  installs skills from GitHub, lists installed skills, and uninstalls.
+  Triggers: "install skill", "manage skills", "list skills", "uninstall skill".
+metadata:
+  version: 0.1.0
+  category: tooling
+  author: isandrel
+---
+
+# Skill Manager
+
+Universal skill manager for AI coding agents. Automatically detects installed agents
+and installs skills using the best available method.
+
+## Supported Agents
+
+Run `scripts/detect_agents.py` to see which agents are available on this system.
+Agent definitions are in `references/agents.md` for easy extensibility.
+
+## Commands
+
+### Install a skill
+
+```bash
+python scripts/install.py <source> [options]
+```
+
+**Source formats:**
+- GitHub shorthand: `owner/repo/path/to/skill`
+- GitHub URL: `https://github.com/owner/repo/tree/main/skills/my-skill`
+- Local path: `/path/to/local/skill`
+
+**Options:**
+| Option             | Description                                            |
+| ------------------ | ------------------------------------------------------ |
+| `--agents <a1,a2>` | Install to specific agents (default: `all`)            |
+| `--local`          | Install to project-local dir (e.g., `.claude/skills/`) |
+| `--symlink`        | Create symlinks instead of copying                     |
+| `--method`         | Force: `auto`, `builtin`, `git`, `download`            |
+
+### List installed skills
+
+```bash
+python scripts/list.py [--agent <agent>]
+```
+
+### Uninstall a skill
+
+```bash
+python scripts/uninstall.py <skill-name> [--agents <a1,a2>]
+```
+
+## Workflow
+
+When user asks to install a skill:
+
+1. **Detect agents** → Run `scripts/detect_agents.py`
+2. **Present options** → Show detected agents, ask which to install to
+3. **Install** → Run `scripts/install.py` with user's choices
+4. **Confirm** → Tell user to restart their agent
+
+## Install Method Priority
+
+1. **Built-in CLI** (if agent supports it, e.g., `claude skill install`)
+2. **Git sparse-checkout** (efficient, downloads only needed files)
+3. **Direct download** (download zip, extract)
+
+## Examples
+
+### Install to user space (default)
+
+```
+python scripts/install.py anthropics/skills/skills/prompt-engineering
+→ ~/.claude/skills/prompt-engineering
+→ ~/.codex/skills/prompt-engineering
+```
+
+### Install to project-local
+
+```
+python scripts/install.py anthropics/skills/skills/prompt-engineering --local
+→ ./.claude/skills/prompt-engineering
+```
+
+### Install using symlink (for development)
+
+```
+python scripts/install.py /path/to/local/skill --symlink --agents claude
+→ ~/.claude/skills/my-skill → /path/to/local/skill
+```
+
+## Requirements
+
+- Python 3.8+
+- Git (for sparse-checkout method)
+- No external dependencies (stdlib only)
+
+## References
+
+- [references/agents.md](references/agents.md) - Agent detection and install paths

--- a/skills/tooling/skill-manager/references/agents.md
+++ b/skills/tooling/skill-manager/references/agents.md
@@ -1,0 +1,121 @@
+# Supported Agents
+
+Agent definitions for skill-manager. Add new agents here.
+
+## Agent Registry
+
+| Agent      | Detection             | User Skills Path             | Project Skills Path |
+| ---------- | --------------------- | ---------------------------- | ------------------- |
+| `claude`   | `claude --version`    | `~/.claude/skills/`          | `.claude/skills/`   |
+| `codex`    | `codex --version`     | `~/.codex/skills/`           | `.codex/skills/`    |
+| `opencode` | `opencode --version`  | `~/.config/opencode/skills/` | `.opencode/skills/` |
+| `cursor`   | `~/.cursor/` exists   | `~/.cursor/skills/`          | `.cursor/skills/`   |
+| `windsurf` | `~/.windsurf/` exists | `~/.windsurf/skills/`        | `.windsurf/skills/` |
+| `copilot`  | `.github/copilot/`    | `.github/copilot/skills/`    | (project-only)      |
+
+---
+
+## Agent Details
+
+### Claude Code (Anthropic)
+
+| Property             | Value                                                                       |
+| -------------------- | --------------------------------------------------------------------------- |
+| **CLI**              | `claude`                                                                    |
+| **Built-in install** | `claude skill install owner/repo/path`                                      |
+| **Config**           | `~/.claude/settings.json`                                                   |
+| **Docs**             | [Claude Code Skills](https://docs.anthropic.com/en/docs/claude-code/skills) |
+
+**Notes:**
+- Skills are auto-loaded on startup
+- Supports both user (`~/.claude/skills/`) and project (`.claude/skills/`) skills
+- Project skills take precedence
+
+---
+
+### Codex (OpenAI)
+
+| Property             | Value                                           |
+| -------------------- | ----------------------------------------------- |
+| **CLI**              | `codex`                                         |
+| **Built-in install** | `codex skill install owner/repo/path`           |
+| **Config**           | `$CODEX_HOME` (default: `~/.codex/`)            |
+| **Docs**             | [Codex Skills](https://github.com/openai/codex) |
+
+**Notes:**
+- Similar skill format to Claude Code
+- Curated skills at `openai/skills` repo
+- Preinstalled system skills in `.system/`
+
+---
+
+### OpenCode
+
+| Property             | Value                                              |
+| -------------------- | -------------------------------------------------- |
+| **CLI**              | `opencode`                                         |
+| **Built-in install** | ❌ (use file-based)                                 |
+| **Config**           | `~/.config/opencode/opencode.jsonc`                |
+| **Docs**             | [OpenCode Skills](https://opencode.ai/docs/skills) |
+
+**Notes:**
+- Searches for `SKILL.md` in configured paths
+- Compatible with Claude Code skill format
+
+---
+
+### Cursor
+
+| Property             | Value                                                        |
+| -------------------- | ------------------------------------------------------------ |
+| **CLI**              | ❌                                                            |
+| **Built-in install** | ❌ (use file-based)                                           |
+| **Config**           | `~/.cursor/`                                                 |
+| **Docs**             | [Cursor Rules](https://docs.cursor.com/context/rules-for-ai) |
+
+**Notes:**
+- Uses `.cursorrules` file format
+- Skills in `~/.cursor/skills/` are experimental
+
+---
+
+### Windsurf (Codeium)
+
+| Property             | Value                                              |
+| -------------------- | -------------------------------------------------- |
+| **CLI**              | ❌                                                  |
+| **Built-in install** | ❌ (use file-based)                                 |
+| **Config**           | `~/.windsurf/`                                     |
+| **Docs**             | [Windsurf Docs](https://docs.codeium.com/windsurf) |
+
+**Notes:**
+- Similar architecture to Cursor
+- Skills support is emerging
+
+---
+
+## Adding a New Agent
+
+1. Add entry to the table above
+2. Add to `AGENTS` list in `scripts/detect_agents.py`:
+
+```python
+Agent(
+    name="new-agent",
+    display_name="New Agent",
+    skills_path=Path.home() / ".new-agent" / "skills",
+    local_skills_dir=".new-agent/skills",
+    detect_cmd=["new-agent", "--version"],  # or use detect_path
+    builtin_install="new-agent skill install",  # if supported
+),
+```
+
+3. Test detection: `python scripts/detect_agents.py`
+
+---
+
+## Related Resources
+
+- [Agent Skills Specification](https://agentskills.io/specification)
+- [Anthropic Skills Repo](https://github.com/anthropics/skills)
+- [OpenAI Skills Repo](https://github.com/openai/skills)

--- a/skills/tooling/skill-manager/scripts/detect_agents.py
+++ b/skills/tooling/skill-manager/scripts/detect_agents.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Detect installed AI coding agents."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Agent:
+    """Agent definition."""
+    name: str
+    display_name: str
+    skills_path: Path
+    local_skills_dir: str  # e.g., ".claude/skills" for project-local
+    detect_cmd: list[str] | None = None
+    detect_path: Path | None = None
+    builtin_install: str | None = None
+
+
+# Agent registry - add new agents here
+AGENTS: list[Agent] = [
+    Agent(
+        name="claude",
+        display_name="Claude Code",
+        skills_path=Path.home() / ".claude" / "skills",
+        local_skills_dir=".claude/skills",
+        detect_cmd=["claude", "--version"],
+        builtin_install="claude skill install",
+    ),
+    Agent(
+        name="codex",
+        display_name="Codex",
+        skills_path=Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "skills",
+        local_skills_dir=".codex/skills",
+        detect_cmd=["codex", "--version"],
+        builtin_install="codex skill install",
+    ),
+    Agent(
+        name="opencode",
+        display_name="OpenCode",
+        skills_path=Path.home() / ".config" / "opencode" / "skills",
+        local_skills_dir=".opencode/skills",
+        detect_cmd=["opencode", "--version"],
+    ),
+    Agent(
+        name="cursor",
+        display_name="Cursor",
+        skills_path=Path.home() / ".cursor" / "skills",
+        local_skills_dir=".cursor/skills",
+        detect_path=Path.home() / ".cursor",
+    ),
+    Agent(
+        name="windsurf",
+        display_name="Windsurf",
+        skills_path=Path.home() / ".windsurf" / "skills",
+        local_skills_dir=".windsurf/skills",
+        detect_path=Path.home() / ".windsurf",
+    ),
+]
+
+
+def detect_agent(agent: Agent) -> dict | None:
+    """Check if an agent is installed."""
+    version = None
+    
+    # Check by command
+    if agent.detect_cmd:
+        if shutil.which(agent.detect_cmd[0]):
+            try:
+                result = subprocess.run(
+                    agent.detect_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    version = result.stdout.strip().split("\n")[0]
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+    
+    # Check by path existence
+    if agent.detect_path and agent.detect_path.exists():
+        version = version or "detected"
+    
+    if version:
+        return {
+            "name": agent.name,
+            "display_name": agent.display_name,
+            "version": version,
+            "skills_path": str(agent.skills_path),
+            "local_skills_dir": agent.local_skills_dir,
+            "builtin_install": agent.builtin_install,
+        }
+    return None
+
+
+def detect_all() -> list[dict]:
+    """Detect all installed agents."""
+    detected = []
+    for agent in AGENTS:
+        result = detect_agent(agent)
+        if result:
+            detected.append(result)
+    return detected
+
+
+def main(argv: list[str]) -> int:
+    """Main entry point."""
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Detect installed AI agents")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--agent", help="Check specific agent only")
+    args = parser.parse_args(argv)
+    
+    if args.agent:
+        agent = next((a for a in AGENTS if a.name == args.agent), None)
+        if not agent:
+            print(f"Unknown agent: {args.agent}", file=sys.stderr)
+            return 1
+        result = detect_agent(agent)
+        agents = [result] if result else []
+    else:
+        agents = detect_all()
+    
+    if args.format == "json":
+        print(json.dumps(agents, indent=2))
+    else:
+        if not agents:
+            print("🔍 No AI agents detected.")
+            return 0
+        print("🤖 Detected AI Agents:")
+        for i, agent in enumerate(agents, 1):
+            icon = "🔧" if agent["builtin_install"] else "📁"
+            print(f"  {icon} [{i}] {agent['display_name']} ({agent['version']})")
+            print(f"      └─ {agent['skills_path']}")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/tooling/skill-manager/scripts/install.py
+++ b/skills/tooling/skill-manager/scripts/install.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Install a skill from GitHub or local path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# Import agent detection
+from detect_agents import AGENTS, detect_all
+
+
+@dataclass
+class Source:
+    """Parsed skill source."""
+    owner: str
+    repo: str
+    ref: str
+    path: str
+    skill_name: str
+
+
+class InstallError(Exception):
+    """Installation error."""
+    pass
+
+
+def parse_github_url(url: str, default_ref: str = "main") -> Source:
+    """Parse a GitHub URL into components."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.netloc not in ("github.com", "www.github.com"):
+        raise InstallError("Only GitHub URLs are supported.")
+    
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) < 2:
+        raise InstallError("Invalid GitHub URL.")
+    
+    owner, repo = parts[0], parts[1]
+    ref = default_ref
+    subpath = ""
+    
+    if len(parts) > 2:
+        if parts[2] in ("tree", "blob"):
+            if len(parts) < 4:
+                raise InstallError("GitHub URL missing ref or path.")
+            ref = parts[3]
+            subpath = "/".join(parts[4:])
+        else:
+            subpath = "/".join(parts[2:])
+    
+    skill_name = subpath.rstrip("/").split("/")[-1] if subpath else repo
+    
+    return Source(
+        owner=owner,
+        repo=repo,
+        ref=ref,
+        path=subpath,
+        skill_name=skill_name,
+    )
+
+
+def parse_shorthand(shorthand: str, default_ref: str = "main") -> Source:
+    """Parse owner/repo/path shorthand."""
+    parts = shorthand.split("/")
+    if len(parts) < 2:
+        raise InstallError("Invalid shorthand. Use: owner/repo[/path/to/skill]")
+    
+    owner = parts[0]
+    repo = parts[1]
+    path = "/".join(parts[2:]) if len(parts) > 2 else ""
+    skill_name = parts[-1] if len(parts) > 2 else repo
+    
+    return Source(
+        owner=owner,
+        repo=repo,
+        ref=default_ref,
+        path=path,
+        skill_name=skill_name,
+    )
+
+
+def github_request(url: str) -> bytes:
+    """Make a GitHub API request."""
+    headers = {"User-Agent": "skill-manager"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        raise InstallError(f"HTTP {e.code}: {e.reason}") from e
+
+
+def install_builtin(source: Source, agent_cmd: str) -> bool:
+    """Try to install using agent's built-in command."""
+    cmd_parts = agent_cmd.split()
+    skill_ref = f"{source.owner}/{source.repo}"
+    if source.path:
+        skill_ref += f"/{source.path}"
+    
+    cmd = [*cmd_parts, skill_ref]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def install_git_sparse(source: Source, dest: Path) -> bool:
+    """Install using git sparse-checkout."""
+    if not shutil.which("git"):
+        return False
+    
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_dir = Path(tmp) / "repo"
+        repo_url = f"https://github.com/{source.owner}/{source.repo}.git"
+        
+        # Clone with sparse checkout
+        clone_cmd = [
+            "git", "clone",
+            "--filter=blob:none",
+            "--depth", "1",
+            "--sparse",
+            "--single-branch",
+            "--branch", source.ref,
+            repo_url,
+            str(repo_dir),
+        ]
+        
+        try:
+            subprocess.run(clone_cmd, capture_output=True, check=True, timeout=60)
+        except subprocess.CalledProcessError:
+            return False
+        
+        # Set sparse-checkout to only include our path
+        if source.path:
+            sparse_cmd = ["git", "-C", str(repo_dir), "sparse-checkout", "set", source.path]
+            subprocess.run(sparse_cmd, capture_output=True, check=True)
+        
+        # Copy skill files to destination
+        src_path = repo_dir / source.path if source.path else repo_dir
+        if not src_path.exists():
+            return False
+        
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src_path, dest, dirs_exist_ok=True)
+        
+        # Remove .git if copied
+        git_dir = dest / ".git"
+        if git_dir.exists():
+            shutil.rmtree(git_dir)
+        
+        return True
+
+
+def install_download(source: Source, dest: Path) -> bool:
+    """Install by downloading repo zip."""
+    zip_url = f"https://codeload.github.com/{source.owner}/{source.repo}/zip/{source.ref}"
+    
+    try:
+        payload = github_request(zip_url)
+    except InstallError:
+        return False
+    
+    with tempfile.TemporaryDirectory() as tmp:
+        zip_path = Path(tmp) / "repo.zip"
+        zip_path.write_bytes(payload)
+        
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmp)
+        
+        # Find extracted directory (usually repo-ref)
+        extracted = next(Path(tmp).glob(f"{source.repo}-*"), None)
+        if not extracted:
+            return False
+        
+        src_path = extracted / source.path if source.path else extracted
+        if not src_path.exists():
+            return False
+        
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src_path, dest, dirs_exist_ok=True)
+        return True
+
+
+def install_local(local_path: Path, dest: Path, symlink: bool = False) -> bool:
+    """Install from local path."""
+    if not local_path.exists():
+        return False
+    
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    
+    if symlink:
+        if dest.exists():
+            dest.unlink() if dest.is_symlink() else shutil.rmtree(dest)
+        dest.symlink_to(local_path.resolve())
+    else:
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(local_path, dest, dirs_exist_ok=True)
+    
+    return True
+
+
+def install_skill(
+    source_str: str,
+    agents: list[str] | None = None,
+    symlink: bool = False,
+    method: str = "auto",
+    local: bool = False,
+) -> dict:
+    """Install a skill to specified agents."""
+    results = {"installed": [], "failed": [], "skipped": []}
+    
+    # Parse source
+    local_path = Path(source_str)
+    if local_path.exists():
+        source = None
+        skill_name = local_path.name
+    elif source_str.startswith("http"):
+        source = parse_github_url(source_str)
+        skill_name = source.skill_name
+    else:
+        source = parse_shorthand(source_str)
+        skill_name = source.skill_name
+    
+    # Detect agents
+    detected = {a["name"]: a for a in detect_all()}
+    
+    if not detected:
+        raise InstallError("No AI agents detected on this system.")
+    
+    # Filter to requested agents
+    if agents and agents != ["all"]:
+        target_agents = {k: v for k, v in detected.items() if k in agents}
+        if not target_agents:
+            raise InstallError(f"None of the specified agents found: {agents}")
+    else:
+        target_agents = detected
+    
+    # Install to each agent
+    for name, agent in target_agents.items():
+        # Use project-local path if --local flag is set
+        if local:
+            base = Path.cwd() / agent.get("local_skills_dir", f".{name}/skills")
+            dest = base / skill_name
+        else:
+            dest = Path(agent["skills_path"]) / skill_name
+        
+        if dest.exists() and not symlink:
+            results["skipped"].append({
+                "agent": name,
+                "reason": "Already exists",
+                "path": str(dest),
+            })
+            continue
+        
+        success = False
+        method_used = None
+        
+        # Local install
+        if local_path.exists():
+            success = install_local(local_path, dest, symlink)
+            method_used = "symlink" if symlink else "copy"
+        
+        # GitHub install
+        elif source:
+            # Try built-in first
+            if method in ("auto", "builtin") and agent.get("builtin_install"):
+                success = install_builtin(source, agent["builtin_install"])
+                if success:
+                    method_used = "builtin"
+            
+            # Try git sparse-checkout
+            if not success and method in ("auto", "git"):
+                success = install_git_sparse(source, dest)
+                if success:
+                    method_used = "git"
+            
+            # Try download
+            if not success and method in ("auto", "download"):
+                success = install_download(source, dest)
+                if success:
+                    method_used = "download"
+        
+        if success:
+            results["installed"].append({
+                "agent": name,
+                "path": str(dest),
+                "method": method_used,
+            })
+        else:
+            results["failed"].append({
+                "agent": name,
+                "path": str(dest),
+            })
+    
+    return results
+
+
+def main(argv: list[str]) -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Install a skill")
+    parser.add_argument("source", help="GitHub URL, shorthand, or local path")
+    parser.add_argument("--agents", help="Comma-separated agents or 'all'", default="all")
+    parser.add_argument("--symlink", action="store_true", help="Create symlinks")
+    parser.add_argument("--local", action="store_true", help="Install to project-local skills dir")
+    parser.add_argument("--method", choices=["auto", "builtin", "git", "download"], default="auto")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+    
+    agents = args.agents.split(",") if args.agents != "all" else ["all"]
+    
+    try:
+        results = install_skill(args.source, agents, args.symlink, args.method, args.local)
+    except InstallError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    
+    if args.format == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        if results["installed"]:
+            print("✅ Installed:")
+            for item in results["installed"]:
+                print(f"   📦 {item['agent']}: {item['path']} ({item['method']})")
+        if results["skipped"]:
+            print("⏭️  Skipped:")
+            for item in results["skipped"]:
+                print(f"   ⚠️  {item['agent']}: {item['reason']}")
+        if results["failed"]:
+            print("❌ Failed:")
+            for item in results["failed"]:
+                print(f"   💥 {item['agent']}: {item['path']}")
+        
+        if results["installed"]:
+            print("\n🔄 Restart your agents to load the new skill.")
+    
+    return 1 if results["failed"] and not results["installed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/tooling/skill-manager/scripts/list.py
+++ b/skills/tooling/skill-manager/scripts/list.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""List installed skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from detect_agents import detect_all
+
+
+def list_skills(agent_filter: str | None = None) -> dict:
+    """List installed skills for all or specific agents."""
+    detected = detect_all()
+    
+    if agent_filter:
+        detected = [a for a in detected if a["name"] == agent_filter]
+    
+    results = {}
+    for agent in detected:
+        skills_path = Path(agent["skills_path"])
+        skills = []
+        
+        if skills_path.exists():
+            for skill_dir in skills_path.iterdir():
+                if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
+                    skills.append({
+                        "name": skill_dir.name,
+                        "path": str(skill_dir),
+                        "symlink": skill_dir.is_symlink(),
+                    })
+        
+        results[agent["name"]] = {
+            "display_name": agent["display_name"],
+            "skills_path": agent["skills_path"],
+            "skills": sorted(skills, key=lambda x: x["name"]),
+        }
+    
+    return results
+
+
+def main(argv: list[str]) -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="List installed skills")
+    parser.add_argument("--agent", help="Filter to specific agent")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+    
+    results = list_skills(args.agent)
+    
+    if args.format == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        if not results:
+            print("🔍 No AI agents detected.")
+            return 0
+        
+        for name, data in results.items():
+            skills = data["skills"]
+            count = len(skills)
+            print(f"🤖 {data['display_name']} ({count} skill{'s' if count != 1 else ''}):")
+            
+            if not skills:
+                print("   (none)")
+            else:
+                for skill in skills:
+                    icon = "🔗" if skill["symlink"] else "📦"
+                    print(f"   {icon} {skill['name']}")
+            print()
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/tooling/skill-manager/scripts/uninstall.py
+++ b/skills/tooling/skill-manager/scripts/uninstall.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Uninstall a skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from detect_agents import detect_all
+
+
+def uninstall_builtin(skill_name: str, agent: dict) -> bool:
+    """Try to uninstall using agent's built-in command."""
+    if not agent.get("builtin_install"):
+        return False
+    
+    # Derive uninstall command from install command
+    # "claude skill install" -> "claude skill remove"
+    cmd_parts = agent["builtin_install"].replace("install", "remove").split()
+    cmd = [*cmd_parts, skill_name]
+    
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def uninstall_skill(
+    skill_name: str,
+    agents: list[str] | None = None,
+) -> dict:
+    """Uninstall a skill from specified agents."""
+    results = {"removed": [], "not_found": []}
+    
+    detected = {a["name"]: a for a in detect_all()}
+    
+    if not detected:
+        return results
+    
+    # Filter to requested agents
+    if agents and agents != ["all"]:
+        target_agents = {k: v for k, v in detected.items() if k in agents}
+    else:
+        target_agents = detected
+    
+    for name, agent in target_agents.items():
+        skill_path = Path(agent["skills_path"]) / skill_name
+        removed = False
+        method = None
+        
+        # Try built-in uninstall first
+        if agent.get("builtin_install"):
+            if uninstall_builtin(skill_name, agent):
+                removed = True
+                method = "builtin"
+        
+        # Fall back to file-based removal
+        if not removed and skill_path.exists():
+            if skill_path.is_symlink():
+                skill_path.unlink()
+            else:
+                shutil.rmtree(skill_path)
+            removed = True
+            method = "file"
+        
+        if removed:
+            results["removed"].append({
+                "agent": name,
+                "path": str(skill_path),
+                "method": method,
+            })
+        else:
+            results["not_found"].append({
+                "agent": name,
+                "path": str(skill_path),
+            })
+    
+    return results
+
+
+def main(argv: list[str]) -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Uninstall a skill")
+    parser.add_argument("skill_name", help="Name of skill to uninstall")
+    parser.add_argument("--agents", help="Comma-separated agents or 'all'", default="all")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+    
+    agents = args.agents.split(",") if args.agents != "all" else ["all"]
+    results = uninstall_skill(args.skill_name, agents)
+    
+    if args.format == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        if results["removed"]:
+            print("🗑️  Removed:")
+            for item in results["removed"]:
+                print(f"   ✅ {item['agent']}: {item['path']} ({item['method']})")
+        if results["not_found"]:
+            print("⚠️  Not found:")
+            for item in results["not_found"]:
+                print(f"   📭 {item['agent']}")
+    
+    return 0 if results["removed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
Universal skill manager for AI coding agents with:
- Auto-detect installed agents (Claude, Codex, OpenCode, Cursor, Windsurf)
- Install from GitHub or local paths
- Built-in CLI support + fallback chain
- List/uninstall commands
- `--local` and `--symlink` options
- Zero dependencies (stdlib only)

## Files
- `SKILL.md` - Main skill definition
- `scripts/detect_agents.py` - Agent detection
- `scripts/install.py` - Install with fallback
- `scripts/list.py` - List installed skills
- `scripts/uninstall.py` - Remove skills
- `references/agents.md` - Agent registry