### PR TITLE
✨ feat(skill-manager): add unified sm CLI entry point

### DIFF
--- a/skills/tooling/skill-manager/sm
+++ b/skills/tooling/skill-manager/sm
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Skill Manager CLI - Universal AI agent skills manager.
+
+Usage:
+    sm detect              # Detect installed agents
+    sm list [--agent X]    # List installed skills
+    sm install <source>    # Install from GitHub/local
+    sm uninstall <name>    # Remove a skill
+    sm --help              # Show help
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for imports
+SCRIPT_DIR = Path(__file__).parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="sm",
+        description="🤖 Skill Manager - Universal AI agent skills manager",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
+    
+    # detect
+    detect_p = subparsers.add_parser("detect", help="Detect installed AI agents")
+    detect_p.add_argument("--format", choices=["text", "json"], default="text")
+    detect_p.add_argument("--agent", help="Check specific agent only")
+    
+    # list
+    list_p = subparsers.add_parser("list", help="List installed skills")
+    list_p.add_argument("--agent", help="Filter to specific agent")
+    list_p.add_argument("--format", choices=["text", "json"], default="text")
+    
+    # install
+    install_p = subparsers.add_parser("install", help="Install a skill")
+    install_p.add_argument("source", help="GitHub URL, shorthand, or local path")
+    install_p.add_argument("--agents", default="all", help="Target agents")
+    install_p.add_argument("--local", action="store_true", help="Install to project dir")
+    install_p.add_argument("--symlink", action="store_true", help="Create symlinks")
+    install_p.add_argument("--method", choices=["auto", "builtin", "git", "download"], default="auto")
+    install_p.add_argument("--format", choices=["text", "json"], default="text")
+    
+    # uninstall
+    uninstall_p = subparsers.add_parser("uninstall", help="Uninstall a skill")
+    uninstall_p.add_argument("skill_name", help="Name of skill to remove")
+    uninstall_p.add_argument("--agents", default="all", help="Target agents")
+    uninstall_p.add_argument("--format", choices=["text", "json"], default="text")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 0
+    
+    # Import and run the appropriate module
+    if args.command == "detect":
+        from detect_agents import main as detect_main
+        argv = []
+        if args.format != "text":
+            argv.extend(["--format", args.format])
+        if args.agent:
+            argv.extend(["--agent", args.agent])
+        return detect_main(argv)
+    
+    elif args.command == "list":
+        from list import main as list_main
+        argv = []
+        if args.agent:
+            argv.extend(["--agent", args.agent])
+        if args.format != "text":
+            argv.extend(["--format", args.format])
+        return list_main(argv)
+    
+    elif args.command == "install":
+        from install import main as install_main
+        argv = [args.source]
+        if args.agents != "all":
+            argv.extend(["--agents", args.agents])
+        if args.local:
+            argv.append("--local")
+        if args.symlink:
+            argv.append("--symlink")
+        if args.method != "auto":
+            argv.extend(["--method", args.method])
+        if args.format != "text":
+            argv.extend(["--format", args.format])
+        return install_main(argv)
+    
+    elif args.command == "uninstall":
+        from uninstall import main as uninstall_main
+        argv = [args.skill_name]
+        if args.agents != "all":
+            argv.extend(["--agents", args.agents])
+        if args.format != "text":
+            argv.extend(["--format", args.format])
+        return uninstall_main(argv)
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3

## Description
Adds a unified `sm` CLI entry point that provides a single command interface for all skill-manager operations.

## Commands
- `sm detect` - Detect installed AI agents
- `sm list` - List installed skills
- `sm install` - Install a skill
- `sm uninstall` - Uninstall a skill