### PR TITLE
✨ feat(skill-manager): add Antigravity agent support

### DIFF
--- a/skills/tooling/skill-manager/scripts/detect_agents.py
+++ b/skills/tooling/skill-manager/scripts/detect_agents.py
@@ -63,6 +63,13 @@ AGENTS: list[Agent] = [
         local_skills_dir=".windsurf/skills",
         detect_path=Path.home() / ".windsurf",
     ),
+    Agent(
+        name="antigravity",
+        display_name="Antigravity",
+        skills_path=Path.home() / ".gemini" / "antigravity" / "skills",
+        local_skills_dir=".agent/skills",
+        detect_path=Path.home() / ".gemini" / "antigravity",
+    ),
 ]
 
 


### PR DESCRIPTION
Add Google's Antigravity AI agent to the skill manager.

## Changes
- Add Antigravity to the agent registry in `detect_agents.py`
- Global skills path: `~/.gemini/antigravity/skills/`
- Local skills path: `.agent/skills/`
- Detection via path existence

Closes #5