### PR TITLE
✨ feat: add md-to-email skill

### DIFF
--- a/skills/tooling/md-to-email/README.md
+++ b/skills/tooling/md-to-email/README.md
@@ -1,0 +1,37 @@
+# MD to Email Skill
+
+A skill for AI agents to transform Markdown content into professional, styled HTML emails.
+
+## Features
+
+- 📝 **Markdown Support**: Use standard Markdown for drafting.
+- 🎨 **Professional Styling**: Clean, modern CSS template.
+- 📧 **Email Safe**: Uses inline-compatible styles for broad support.
+- 🚀 **Automation Ready**: Simple Python script for batch conversion.
+
+## Installation
+
+This skill requires the `markdown` Python library.
+
+```bash
+uv pip install markdown
+```
+
+## Usage
+
+### As a User
+Ask your agent:
+"Can you convert this markdown to a beautiful email draft for me?"
+
+### As a Developer
+The skill provides a script to generate the HTML:
+
+```bash
+python scripts/md_to_html.py my_email.md > my_email.html
+```
+
+## Structure
+
+- `SKILL.md`: Instructions for the AI agent.
+- `scripts/md_to_html.py`: Transformation engine.
+- `references/email_template.html`: Professional HTML/CSS skeleton.

--- a/skills/tooling/md-to-email/SKILL.md
+++ b/skills/tooling/md-to-email/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: md-to-email
+description: "Transforms Markdown text into professional, styled HTML for emails. Use when you want to send emails with rich formatting (bold, lists, links, code) that look consistent across email clients. Perfect for job applications, newsletters, or professional correspondence where Markdown's simplicity is preferred but HTML's styling is required."
+metadata:
+  version: 0.1.0
+  category: tooling
+  author: isandrel
+---
+
+# MD to Email
+
+This skill facilitates the creation of beautiful HTML emails from Markdown source. It solves the problem of inconsistent styling when pasting Markdown directly into email clients.
+
+## Workflow
+
+1.  **Draft in Markdown**: Write your email content using standard Markdown syntax.
+2.  **Transform to HTML**: Use the provided script or instructions to convert the Markdown into styled HTML.
+3.  **Create Draft**: Use a tool like `gmail.createDraft` with `isHtml: true` to send or save the formatted email.
+
+## Transformation Methods
+
+### Method 1: Python Script (Automated)
+
+Run the included transformation script to generate the HTML.
+
+```bash
+python scripts/md_to_html.py message.md > message.html
+```
+
+The script uses a professional template located in `references/email_template.html`.
+
+### Method 2: Manual (In-Context)
+
+If you cannot run scripts, you can manually wrap your Markdown-converted HTML (which Claude can generate) with the following structure:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        /* See references/email_template.html for full CSS */
+        body { font-family: sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        /* ... inline styles ... */
+    </style>
+</head>
+<body>
+    <!-- YOUR CONVERTED HTML HERE -->
+</body>
+</html>
+```
+
+## Styling Principles
+
+The included template follows these email-safe principles:
+- **Max Width**: 600px for readability on desktop and mobile.
+- **Typography**: System-default sans-serif stack for fast loading and clean look.
+- **Spacing**: Generous margins and line-height for a modern feel.
+- **Responsive**: Standard layout that works well on small screens.
+
+## Resources
+
+### scripts/
+- `md_to_html.py`: Converts Markdown files to HTML using the `markdown` library and the default template.
+
+### references/
+- `email_template.html`: The base HTML/CSS skeleton used for styling.

--- a/skills/tooling/md-to-email/references/email_template.html
+++ b/skills/tooling/md-to-email/references/email_template.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        h1,
+        h2,
+        h3 {
+            color: #111;
+            margin-top: 24px;
+        }
+
+        p {
+            margin-bottom: 16px;
+        }
+
+        ul,
+        ol {
+            margin-bottom: 16px;
+            padding-left: 20px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
+
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        code {
+            background-color: #f4f4f4;
+            padding: 2px 4px;
+            border-radius: 4px;
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        }
+
+        pre {
+            background-color: #f4f4f4;
+            padding: 16px;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+
+        blockquote {
+            border-left: 4px solid #ddd;
+            padding-left: 16px;
+            margin-left: 0;
+            color: #666;
+            font-style: italic;
+        }
+
+        hr {
+            border: 0;
+            border-top: 1px solid #eee;
+            margin: 24px 0;
+        }
+    </style>
+</head>
+
+<body>
+    {{content}}
+</body>
+
+</html>

--- a/skills/tooling/md-to-email/scripts/md_to_html.py
+++ b/skills/tooling/md-to-email/scripts/md_to_html.py
@@ -1,0 +1,29 @@
+import markdown
+import sys
+import os
+
+def convert_md_to_html(md_text, template_path):
+    # Convert Markdown to HTML
+    html_content = markdown.markdown(md_text, extensions=['extra', 'codehilite'])
+    
+    # Read template
+    with open(template_path, 'r') as f:
+        template = f.read()
+    
+    # Inject content
+    final_html = template.replace('{{content}}', html_content)
+    return final_html
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python md_to_html.py <markdown_file> [template_file]")
+        sys.exit(1)
+    
+    md_file = sys.argv[1]
+    template_file = sys.argv[2] if len(sys.argv) > 2 else os.path.join(os.path.dirname(__file__), '../references/email_template.html')
+    
+    with open(md_file, 'r') as f:
+        md_text = f.read()
+    
+    html_output = convert_md_to_html(md_text, template_file)
+    print(html_output)


### PR DESCRIPTION
Closes #13

## Description
Adds a new skill for transforming Markdown into professional HTML emails.

## What's Included
- 📝 **SKILL.md**: AI agent instructions with two transformation methods
- 🐍 **md_to_html.py**: Python script using markdown library
- 🎨 **email_template.html**: Email-safe HTML/CSS template (600px width, system fonts)
- 📖 **README.md**: User documentation and installation guide

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
Tested Python script locally with sample Markdown files. Template renders properly across email clients.