### PR TITLE
✨ feat(md-to-email): add Gmail template and update docs

### DIFF
--- a/skills/tooling/md-to-email/SKILL.md
+++ b/skills/tooling/md-to-email/SKILL.md
@@ -2,66 +2,71 @@
 name: md-to-email
 description: "Transforms Markdown text into professional, styled HTML for emails. Use when you want to send emails with rich formatting (bold, lists, links, code) that look consistent across email clients. Perfect for job applications, newsletters, or professional correspondence where Markdown's simplicity is preferred but HTML's styling is required."
 metadata:
-  version: 0.1.0
+  version: 0.2.0
   category: tooling
   author: isandrel
 ---
 
 # MD to Email
 
-This skill facilitates the creation of beautiful HTML emails from Markdown source. It solves the problem of inconsistent styling when pasting Markdown directly into email clients.
+This skill converts Markdown into styled HTML emails. It solves the problem of inconsistent styling when pasting Markdown directly into email clients.
 
 ## Workflow
 
-1.  **Draft in Markdown**: Write your email content using standard Markdown syntax.
-2.  **Transform to HTML**: Use the provided script or instructions to convert the Markdown into styled HTML.
-3.  **Create Draft**: Use a tool like `gmail.createDraft` with `isHtml: true` to send or save the formatted email.
+1. **Draft in Markdown**: Write your email content using standard Markdown syntax.
+   - Use trailing double spaces (`  `) at end of lines to force line breaks (e.g. in signatures).
+2. **Transform to HTML**: Convert the Markdown into styled HTML using the script and a template.
+3. **Preview**: Open the HTML file in a browser to preview.
+4. **Use**: Copy-paste the rendered HTML into your email client, or use a tool like `gmail.createDraft` with `isHtml: true`.
 
-## Transformation Methods
+## Templates
 
-### Method 1: Python Script (Automated)
+Two email templates are available in `references/`:
 
-Run the included transformation script to generate the HTML.
+| Template              | Font              | Style                                                 | Best For                                       |
+| --------------------- | ----------------- | ----------------------------------------------------- | ---------------------------------------------- |
+| `email_template.html` | System sans-serif | Professional, 600px max-width, generous spacing       | Newsletters, formal correspondence             |
+| `gmail_template.html` | Arial, 14px       | Minimal, matches Gmail's default "Sans Serif" compose | Everyday Gmail emails, referrals, applications |
+
+## Usage
+
+### Basic (default template)
 
 ```bash
 python scripts/md_to_html.py message.md > message.html
 ```
 
-The script uses a professional template located in `references/email_template.html`.
+### Gmail-style
 
-### Method 2: Manual (In-Context)
-
-If you cannot run scripts, you can manually wrap your Markdown-converted HTML (which Claude can generate) with the following structure:
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <style>
-        /* See references/email_template.html for full CSS */
-        body { font-family: sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
-        /* ... inline styles ... */
-    </style>
-</head>
-<body>
-    <!-- YOUR CONVERTED HTML HERE -->
-</body>
-</html>
+```bash
+python scripts/md_to_html.py message.md references/gmail_template.html > message.html
 ```
 
-## Styling Principles
+### Preview in browser
 
-The included template follows these email-safe principles:
-- **Max Width**: 600px for readability on desktop and mobile.
-- **Typography**: System-default sans-serif stack for fast loading and clean look.
-- **Spacing**: Generous margins and line-height for a modern feel.
-- **Responsive**: Standard layout that works well on small screens.
+```bash
+open message.html
+```
+
+## Markdown Tips for Emails
+
+- **Line breaks in signatures**: Use trailing double spaces at end of each line:
+  ```markdown
+  --  
+  **Name**  
+  **Title | Company**  
+  📧 email@example.com  
+  📞 +1 (xxx) xxx-xxxx
+  ```
+- **Links**: Use `[text](url)` for clickable links.
+- **Bold**: Use `**text**` for emphasis.
+- **Lists**: Use `1.` for ordered, `-` for unordered.
 
 ## Resources
 
 ### scripts/
-- `md_to_html.py`: Converts Markdown files to HTML using the `markdown` library and the default template.
+- `md_to_html.py`: Converts Markdown files to HTML using the `markdown` library and a template.
 
 ### references/
-- `email_template.html`: The base HTML/CSS skeleton used for styling.
+- `email_template.html`: Professional styled template (600px, system sans-serif).
+- `gmail_template.html`: Gmail-matching minimal template (Arial, 14px).

--- a/skills/tooling/md-to-email/references/gmail_template.html
+++ b/skills/tooling/md-to-email/references/gmail_template.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 14px;
+            line-height: 1.4;
+            color: #222;
+            padding: 0;
+            margin: 0;
+        }
+
+        p {
+            margin: 0 0 12px 0;
+        }
+
+        ol {
+            margin: 0 0 12px 0;
+            padding-left: 24px;
+        }
+
+        li {
+            margin-bottom: 4px;
+        }
+
+        ul {
+            margin: 0 0 12px 0;
+            padding-left: 24px;
+            list-style-type: disc;
+        }
+
+        a {
+            color: #1a73e8;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+
+<body>
+    {{content}}
+</body>
+
+</html>


### PR DESCRIPTION
## Description
Add a Gmail-matching email template and update SKILL.md to v0.2.0.

## Changes
- **New**: `gmail_template.html` — minimal template matching Gmail's default Sans Serif compose style (Arial, 14px)
- **Updated**: `SKILL.md` — dual template documentation, improved usage examples, markdown tips for emails

## Type of Change
- [x] New feature

Closes #15