### PR TITLE
✨ feat(leetcode): add leetcode-obsidian skill

### DIFF
--- a/skills/obsidian/leetcode-obsidian/SKILL.md
+++ b/skills/obsidian/leetcode-obsidian/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: leetcode-obsidian
+description: "Fetch LeetCode problems and generate Obsidian-compatible markdown notes with frontmatter, callouts, solution tabs, and test runner. Use when: (1) Fetching a LeetCode problem by URL, ID, or slug, (2) Creating structured coding problem notes for Obsidian, (3) Building a LeetCode study collection. Triggers: 'leetcode', 'lc problem', 'fetch problem', 'coding problem'."
+---
+
+# LeetCode Obsidian
+
+Fetch LeetCode problems via GraphQL API and generate structured Obsidian notes.
+
+## Setup
+
+Install dependencies globally (one-time):
+
+```bash
+bun install -g nunjucks turndown smol-toml
+```
+
+## Usage
+
+Run the script directly with Bun:
+
+```bash
+# By URL
+bun scripts/fetch_problem.ts "https://leetcode.com/problems/two-sum/"
+
+# By problem ID
+bun scripts/fetch_problem.ts 1
+
+# By slug
+bun scripts/fetch_problem.ts two-sum
+
+# With options
+bun scripts/fetch_problem.ts two-sum --output-dir ~/vault/LeetCode/ --download-images
+
+# Create directly in Obsidian vault and open it
+bun scripts/fetch_problem.ts two-sum --obsidian --open
+
+# Target a specific vault
+bun scripts/fetch_problem.ts two-sum --obsidian --vault "My Vault" --output-dir "LeetCode/"
+```
+
+### Options
+
+| Flag                | Default            | Description                                                           |
+| ------------------- | ------------------ | --------------------------------------------------------------------- |
+| `--output-dir`      | from config or `.` | Directory to save the note (or vault-relative path with `--obsidian`) |
+| `--image-dir`       | `Attachments`      | Subdirectory for downloaded images                                    |
+| `--download-images` | from config        | Download problem images locally                                       |
+| `--site`            | `us`               | LeetCode site: `us` or `cn`                                           |
+| `--config`          | `config.toml`      | Custom config file path                                               |
+| `--template`        | built-in           | Custom Nunjucks/Jinja2 template                                       |
+| `--obsidian`        | from config        | Create note via [Obsidian CLI](https://help.obsidian.md/cli)          |
+| `--vault`           | auto               | Obsidian vault name                                                   |
+| `--open`            | from config        | Open note in Obsidian after creation                                  |
+
+> **Obsidian CLI**: When `--obsidian` is enabled, notes are created via `obsidian create path=<path> content=<text>` for proper vault indexing. Auto-falls back to file write if CLI is unavailable.
+
+### Configuration
+
+Edit `config.toml` to set persistent defaults. CLI flags override config values. See the config file for all available options including filename patterns, note format toggles, and Obsidian integration settings.
+
+## Generated Note Format
+
+The script produces a `.md` file named `{id}. {title}.md` with:
+
+- **YAML frontmatter**: link, questionId, platform, difficulty, tags, dates
+- **Description**: Problem statement converted from HTML to Markdown
+- **Hints**: Rendered as `> [!note]- Hint` Obsidian callouts
+- **Approach**: Intuition + Algorithm callouts (blank for user to fill)
+- **Solutions**: Python tabs with clean solution + test runner
+- **Complexity**: Time/Space table
+- **Notes**: Empty section for user notes
+
+## Template Customization
+
+The note template is at `assets/templates/leetcode_note.md.j2` (Nunjucks/Jinja2 compatible). Available template variables:
+
+| Variable              | Type   | Example                              |
+| --------------------- | ------ | ------------------------------------ |
+| `question.questionId` | str    | `"1"`                                |
+| `question.title`      | str    | `"Two Sum"`                          |
+| `question.titleSlug`  | str    | `"two-sum"`                          |
+| `question.difficulty` | str    | `"Easy"`                             |
+| `question.content`    | str    | Markdown description                 |
+| `question.topicTags`  | list   | `[{"name": "Array"}, ...]`           |
+| `question.hints`      | list   | `["Consider using a hash map", ...]` |
+| `config`              | Config | Full config object                   |
+| `now`                 | str    | `"2026-03-09T16:00"`                 |

--- a/skills/obsidian/leetcode-obsidian/assets/templates/leetcode_note.md.j2
+++ b/skills/obsidian/leetcode-obsidian/assets/templates/leetcode_note.md.j2
@@ -1,0 +1,77 @@
+---
+link: "[{{ question.title }} - LeetCode](https://leetcode.com/problems/{{ question.titleSlug }}/)"
+questionId: {{ question.questionId }}
+platform: LeetCode
+number: {{ question.questionId }}
+difficulty: {{ question.difficulty }}
+company: 
+references: 
+encountered: false
+tags:
+{% for tag in question.topicTags %}  - {{ tag.name | replace(" ", "-") }}
+{% endfor %}related_problems:
+completed: false
+created: {{ now }}
+updated: {{ now }}
+---
+
+## Description
+
+{{ question.content }}
+
+{% for hint in question.hints %}> [!note]- Hint
+> {{ hint }}
+
+{% endfor %}
+## Approach
+
+> [!abstract]- Intuition
+> 
+
+> [!info]- Algorithm
+> 1. 
+
+---
+
+## Solutions
+
+### Code
+
+[tabs]
+
+- Python
+    ```python
+    class Solution:
+        def solution(self):
+    ```
+
+- Python ▶️
+    ```python
+    class Solution:
+        def solution(self):
+            pass
+
+    if __name__ == "__main__":
+        sol = Solution()
+        tests = [
+            # (input_args, expected),
+            ((), None),
+        ]
+        for i, (args, expected) in enumerate(tests, 1):
+            result = sol.solution(*args) if isinstance(args, tuple) else sol.solution(args)
+            status = "✅" if result == expected else "❌"
+            print(f"Test {i}: {status} | Input: {args} | Expected: {expected} | Got: {result}")
+    ```
+
+---
+
+## Complexity
+
+| Metric    | Complexity | Notes |
+| --------- | ---------- | ----- |
+| **Time**  |            |       |
+| **Space** |            |       |
+
+---
+
+## Notes

--- a/skills/obsidian/leetcode-obsidian/config.toml
+++ b/skills/obsidian/leetcode-obsidian/config.toml
@@ -1,0 +1,69 @@
+# =============================================================================
+# LeetCode Obsidian Skill Configuration
+# =============================================================================
+# All settings have sensible defaults. Override only what you need.
+# CLI flags override config values when both are provided.
+# -----------------------------------------------------------------------------
+# General Settings
+# -----------------------------------------------------------------------------
+[settings]
+# LeetCode site: "us" (leetcode.com) or "cn" (leetcode.cn)
+site = "us"
+# Download problem images to local folder
+download_images = true
+# Default programming language for solution skeleton
+# Used to extract the correct code snippet from LeetCode
+language = "python3"
+
+# HTTP User-Agent header for API requests
+# user_agent = "Mozilla/5.0 ..."
+# -----------------------------------------------------------------------------
+# Paths
+# All paths support ~ for home directory expansion.
+# Relative paths are resolved from the current working directory.
+# -----------------------------------------------------------------------------
+[paths]
+# Base output directory for generated notes
+output_dir = "."
+# Subdirectory name for downloaded images (relative to output_dir)
+image_dir = "Attachments"
+# Custom Nunjucks/Jinja2 template path (leave empty to use built-in template)
+# template = "~/my-custom-templates/leetcode.md.j2"
+template = ""
+
+# -----------------------------------------------------------------------------
+# Obsidian Integration
+# Uses the Obsidian CLI (https://help.obsidian.md/cli) when available.
+# -----------------------------------------------------------------------------
+[obsidian]
+# Enable Obsidian CLI integration (creates notes via `obsidian create`)
+enabled = false
+# Vault name (leave empty to use the active vault or cwd-based detection)
+vault = ""
+# Open note in Obsidian after creation
+open_after_create = false
+
+# -----------------------------------------------------------------------------
+# Note Format
+# Controls the generated note structure.
+# -----------------------------------------------------------------------------
+[note]
+# Filename pattern for generated notes
+# Available: {id}, {title}, {slug}, {difficulty}
+filename_pattern = "{id}. {title}"
+# Platform label in frontmatter
+platform = "LeetCode"
+# Include hints as callouts in the note
+include_hints = true
+# Include solution skeleton with test runner
+include_solution = true
+# Include complexity table
+include_complexity = true
+
+# -----------------------------------------------------------------------------
+# API Endpoints
+# Override if using a proxy or self-hosted instance.
+# -----------------------------------------------------------------------------
+[api]
+graphql_url = "https://leetcode.com/graphql"
+graphql_url_cn = "https://leetcode.cn/graphql"

--- a/skills/obsidian/leetcode-obsidian/scripts/fetch_problem.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/fetch_problem.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env bun
+/**
+ * LeetCode Problem Fetcher for Obsidian — CLI entry point.
+ *
+ * Usage:
+ *   bun scripts/fetch_problem.ts <url-or-id-or-slug> [options]
+ *
+ * All configuration lives in config.toml. CLI flags override config values.
+ * Run with --help for all options.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import {
+	loadConfig,
+	makeFilename,
+	expandHome,
+	DEFAULT_CONFIG_PATH,
+} from "./lib/config.ts";
+import { resolveIdentifier, fetchQuestion } from "./lib/leetcode.ts";
+import { renderNote } from "./lib/renderer.ts";
+import { downloadImages } from "./lib/images.ts";
+import { hasObsidianCli, obsidianCreate } from "./lib/obsidian.ts";
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const { values, positionals } = parseArgs({
+	args: Bun.argv.slice(2),
+	options: {
+		"output-dir": { type: "string" },
+		"image-dir": { type: "string" },
+		"download-images": { type: "boolean", default: false },
+		site: { type: "string" },
+		template: { type: "string" },
+		config: { type: "string" },
+		obsidian: { type: "boolean", default: false },
+		vault: { type: "string" },
+		open: { type: "boolean", default: false },
+		help: { type: "boolean", short: "h", default: false },
+	},
+	allowPositionals: true,
+});
+
+if (values.help || positionals.length === 0) {
+	console.log(`
+Usage: bun scripts/fetch_problem.ts <url-or-id-or-slug> [options]
+
+Arguments:
+  identifier              LeetCode problem URL, numeric ID, or slug
+
+Options:
+  --output-dir <dir>      Output directory (default: from config)
+  --image-dir <dir>       Image subdirectory (default: from config)
+  --download-images       Download problem images locally
+  --site <us|cn>          LeetCode site (default: from config)
+  --template <path>       Custom Nunjucks/Jinja2 template
+  --config <path>         Config file path (default: config.toml)
+  --obsidian              Create note via Obsidian CLI
+  --vault <name>          Obsidian vault name
+  --open                  Open note in Obsidian after creation
+  -h, --help              Show this help
+
+Examples:
+  bun scripts/fetch_problem.ts two-sum
+  bun scripts/fetch_problem.ts 1 --output-dir ~/vault/LeetCode/
+  bun scripts/fetch_problem.ts two-sum --obsidian --open
+`);
+	process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const identifier = positionals[0];
+
+// Load config: --config > default config.toml > built-in defaults
+const configPath = values.config
+	? expandHome(values.config)
+	: DEFAULT_CONFIG_PATH;
+const cfg = loadConfig(configPath);
+
+// CLI overrides
+if (values["output-dir"]) cfg.outputDir = expandHome(values["output-dir"]);
+if (values["image-dir"]) cfg.imageDir = values["image-dir"];
+if (values["download-images"]) cfg.downloadImages = true;
+if (values.site) cfg.site = values.site as "us" | "cn";
+if (values.template) cfg.template = expandHome(values.template);
+if (values.obsidian) cfg.obsidianEnabled = true;
+if (values.vault) cfg.obsidianVault = values.vault;
+if (values.open) cfg.obsidianOpen = true;
+
+// Validate template
+if (!existsSync(cfg.template)) {
+	console.error(`❌ Template not found: ${cfg.template}`);
+	process.exit(1);
+}
+
+// Parse identifier
+console.log(`🔍 Parsing identifier: ${identifier}`);
+let slug: string;
+try {
+	slug = await resolveIdentifier(identifier, cfg);
+} catch (e: any) {
+	console.error(`❌ ${e.message}`);
+	process.exit(1);
+}
+console.log(`  → Slug: ${slug}`);
+
+// Fetch question
+console.log(`📥 Fetching problem from LeetCode (${cfg.site})...`);
+let question;
+try {
+	question = await fetchQuestion(slug, cfg);
+} catch (e: any) {
+	console.error(`❌ Failed to fetch problem: ${e.message}`);
+	process.exit(1);
+}
+console.log(
+	`  ✅ ${question.questionId}. ${question.title} (${question.difficulty})`,
+);
+
+// Download images
+if (cfg.downloadImages && question.content) {
+	console.log(`🖼️  Downloading images to: ${join(cfg.outputDir, cfg.imageDir)}`);
+	question.content = await downloadImages(
+		question.content,
+		cfg.outputDir,
+		cfg.imageDir,
+		question.questionId,
+		question.title,
+		cfg.userAgent,
+	);
+}
+
+// Render note
+console.log("📝 Rendering note...");
+const noteContent = renderNote(question, cfg);
+const filename = makeFilename(cfg.filenamePattern, question);
+
+// Save — via Obsidian CLI or direct file write
+if (cfg.obsidianEnabled && hasObsidianCli()) {
+	const notePath =
+		cfg.outputDir !== "." ? `${cfg.outputDir}/${filename}` : filename;
+	console.log("🔮 Creating note via Obsidian CLI...");
+	const success = obsidianCreate(
+		noteContent,
+		notePath,
+		cfg.obsidianVault || undefined,
+		cfg.obsidianOpen,
+	);
+	if (success) {
+		console.log(`✅ Created in Obsidian: ${notePath}`);
+	} else {
+		console.log("  ↪ Falling back to file write...");
+		const outDir = resolve(cfg.outputDir);
+		mkdirSync(outDir, { recursive: true });
+		writeFileSync(join(outDir, filename), noteContent, "utf-8");
+		console.log(`✅ Saved: ${join(outDir, filename)}`);
+	}
+} else {
+	if (cfg.obsidianEnabled)
+		console.warn("⚠️  Obsidian CLI not found, writing to disk instead");
+	const outDir = resolve(cfg.outputDir);
+	mkdirSync(outDir, { recursive: true });
+	const filepath = join(outDir, filename);
+	writeFileSync(filepath, noteContent, "utf-8");
+	console.log(`✅ Saved: ${filepath}`);
+}

--- a/skills/obsidian/leetcode-obsidian/scripts/lib/config.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/lib/config.ts
@@ -1,0 +1,124 @@
+/**
+ * Configuration loader.
+ *
+ * Loads from config.toml with layered overrides:
+ *   built-in defaults → config.toml → CLI args
+ *
+ * All tunables live in config.toml — no magic numbers in source code.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse as parseToml } from "smol-toml";
+import type { Config } from "./types.ts";
+
+export const SKILL_ROOT = resolve(import.meta.dir, "../..");
+export const DEFAULT_CONFIG_PATH = resolve(SKILL_ROOT, "config.toml");
+export const DEFAULT_TEMPLATE_PATH = resolve(
+	SKILL_ROOT,
+	"assets",
+	"templates",
+	"leetcode_note.md.j2",
+);
+
+/** Expand ~ to home directory. */
+export function expandHome(p: string): string {
+	return p.startsWith("~") ? p.replace("~", Bun.env.HOME ?? "") : p;
+}
+
+/** Built-in defaults — overridden by config.toml values. */
+export function defaultConfig(): Config {
+	return {
+		site: "us",
+		downloadImages: true,
+		language: "python3",
+		userAgent:
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+
+		outputDir: ".",
+		imageDir: "Attachments",
+		template: DEFAULT_TEMPLATE_PATH,
+
+		obsidianEnabled: false,
+		obsidianVault: "",
+		obsidianOpen: false,
+
+		filenamePattern: "{id}. {title}",
+		platform: "LeetCode",
+		includeHints: true,
+		includeSolution: true,
+		includeComplexity: true,
+
+		graphqlUrl: "https://leetcode.com/graphql",
+		graphqlUrlCn: "https://leetcode.cn/graphql",
+	};
+}
+
+/** Load and merge config from a TOML file. */
+export function loadConfig(configPath: string = DEFAULT_CONFIG_PATH): Config {
+	const cfg = defaultConfig();
+
+	if (!existsSync(configPath)) return cfg;
+
+	let data: Record<string, any>;
+	try {
+		data = parseToml(readFileSync(configPath, "utf-8"));
+	} catch {
+		return cfg;
+	}
+
+	// settings
+	const s = data.settings ?? {};
+	if (s.site) cfg.site = s.site;
+	if (s.download_images !== undefined) cfg.downloadImages = s.download_images;
+	if (s.language) cfg.language = s.language;
+	if (s.user_agent) cfg.userAgent = s.user_agent;
+
+	// paths
+	const p = data.paths ?? {};
+	if (p.output_dir) cfg.outputDir = expandHome(p.output_dir);
+	if (p.image_dir) cfg.imageDir = p.image_dir;
+	if (p.template) cfg.template = expandHome(p.template);
+
+	// obsidian
+	const o = data.obsidian ?? {};
+	if (o.enabled !== undefined) cfg.obsidianEnabled = o.enabled;
+	if (o.vault) cfg.obsidianVault = o.vault;
+	if (o.open_after_create !== undefined) cfg.obsidianOpen = o.open_after_create;
+
+	// note format
+	const n = data.note ?? {};
+	if (n.filename_pattern) cfg.filenamePattern = n.filename_pattern;
+	if (n.platform) cfg.platform = n.platform;
+	if (n.include_hints !== undefined) cfg.includeHints = n.include_hints;
+	if (n.include_solution !== undefined)
+		cfg.includeSolution = n.include_solution;
+	if (n.include_complexity !== undefined)
+		cfg.includeComplexity = n.include_complexity;
+
+	// api
+	const a = data.api ?? {};
+	if (a.graphql_url) cfg.graphqlUrl = a.graphql_url;
+	if (a.graphql_url_cn) cfg.graphqlUrlCn = a.graphql_url_cn;
+
+	return cfg;
+}
+
+/** Generate filename from pattern and question data. */
+export function makeFilename(
+	pattern: string,
+	question: {
+		questionId: string;
+		title: string;
+		titleSlug: string;
+		difficulty: string;
+	},
+): string {
+	return (
+		pattern
+			.replace("{id}", question.questionId)
+			.replace("{title}", question.title)
+			.replace("{slug}", question.titleSlug)
+			.replace("{difficulty}", question.difficulty) + ".md"
+	);
+}

--- a/skills/obsidian/leetcode-obsidian/scripts/lib/images.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/lib/images.ts
@@ -1,0 +1,49 @@
+/**
+ * Image downloader.
+ *
+ * Downloads images referenced in markdown content and replaces
+ * remote URLs with local relative paths.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import type { Config } from "./types.ts";
+
+/** Download images from content and replace URLs with local paths. */
+export async function downloadImages(
+	content: string,
+	outputDir: string,
+	imageDir: string,
+	questionId: string,
+	title: string,
+	userAgent: string,
+): Promise<string> {
+	const imgFolder = join(outputDir, imageDir, `${questionId}. ${title}`);
+	mkdirSync(imgFolder, { recursive: true });
+
+	const imgPattern = /!\[([^\]]*)\]\(([^)]+)\)/g;
+	let updated = content;
+
+	for (const match of content.matchAll(imgPattern)) {
+		const [, , imgUrl] = match;
+		if (!imgUrl.startsWith("http")) continue;
+
+		const filename = basename(imgUrl).split("?")[0];
+		const localPath = join(imgFolder, filename);
+
+		try {
+			const resp = await fetch(imgUrl, {
+				headers: { "User-Agent": userAgent },
+			});
+			if (!resp.ok) continue;
+
+			writeFileSync(localPath, Buffer.from(await resp.arrayBuffer()));
+			updated = updated.replace(imgUrl, `${basename(imgFolder)}/${filename}`);
+			console.log(`  📷 Downloaded: ${filename}`);
+		} catch (e) {
+			console.warn(`  ⚠️  Failed to download ${imgUrl}: ${e}`);
+		}
+	}
+
+	return updated;
+}

--- a/skills/obsidian/leetcode-obsidian/scripts/lib/leetcode.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/lib/leetcode.ts
@@ -1,0 +1,145 @@
+/**
+ * LeetCode GraphQL API client.
+ *
+ * Handles fetching questions by slug or numeric ID, including
+ * HTML→Markdown conversion of problem descriptions.
+ */
+
+import TurndownService from "turndown";
+import type { Config, Question } from "./types.ts";
+
+/** GraphQL query for problem data — fetches all fields needed for note generation. */
+const QUESTION_QUERY = `
+query questionData($titleSlug: String!) {
+  question(titleSlug: $titleSlug) {
+    questionId
+    title
+    titleSlug
+    content
+    difficulty
+    topicTags { name }
+    hints
+    codeSnippets { lang langSlug code }
+  }
+}`;
+
+/** GraphQL query to resolve a numeric ID to a slug. */
+const ID_LOOKUP_QUERY = `
+query problemsetQuestionList($filters: QuestionListFilterInput) {
+  problemsetQuestionList: questionList(
+    categorySlug: ""
+    limit: 1
+    skip: 0
+    filters: $filters
+  ) {
+    questions: data { titleSlug frontendQuestionId: questionFrontendId }
+  }
+}`;
+
+/** Build request headers from config. */
+function headers(cfg: Config): Record<string, string> {
+	return {
+		Accept: "*/*",
+		"User-Agent": cfg.userAgent,
+		"Content-Type": "application/json",
+	};
+}
+
+/** Get the GraphQL endpoint URL for the configured site. */
+function graphqlUrl(cfg: Config): string {
+	return cfg.site === "cn" ? cfg.graphqlUrlCn : cfg.graphqlUrl;
+}
+
+/**
+ * Resolve a problem identifier (URL, numeric ID, or slug) to a slug.
+ */
+export async function resolveIdentifier(
+	identifier: string,
+	cfg: Config,
+): Promise<string> {
+	// URL: extract slug from /problems/<slug>/
+	const urlMatch = identifier.match(/\/problems\/([^/?#]+)/);
+	if (urlMatch) return urlMatch[1];
+
+	// Numeric ID: look up slug via API
+	if (/^\d+$/.test(identifier)) {
+		return slugFromId(Number(identifier), cfg);
+	}
+
+	// Assume slug
+	return identifier.trim().toLowerCase();
+}
+
+/** Resolve a numeric question ID to its slug. */
+async function slugFromId(questionId: number, cfg: Config): Promise<string> {
+	const resp = await fetch(graphqlUrl(cfg), {
+		method: "POST",
+		headers: headers(cfg),
+		body: JSON.stringify({
+			query: ID_LOOKUP_QUERY,
+			variables: { filters: { searchKeywords: String(questionId) } },
+		}),
+	});
+
+	if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+
+	const data = (await resp.json()) as any;
+	const questions = data?.data?.problemsetQuestionList?.questions ?? [];
+	const match = questions.find(
+		(q: any) => q.frontendQuestionId === String(questionId),
+	);
+
+	if (!match) throw new Error(`Could not find problem with ID ${questionId}`);
+	return match.titleSlug;
+}
+
+/** Fetch full question data from LeetCode GraphQL API. */
+export async function fetchQuestion(
+	slug: string,
+	cfg: Config,
+): Promise<Question> {
+	const resp = await fetch(graphqlUrl(cfg), {
+		method: "POST",
+		headers: headers(cfg),
+		body: JSON.stringify({
+			query: QUESTION_QUERY,
+			variables: { titleSlug: slug },
+		}),
+	});
+
+	if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+
+	const data = (await resp.json()) as any;
+	const question = data?.data?.question;
+	if (!question) throw new Error(`Problem '${slug}' not found on LeetCode`);
+
+	// Convert HTML description to Markdown
+	if (question.content) {
+		question.content = htmlToMarkdown(question.content);
+	}
+
+	return question as Question;
+}
+
+/** Convert HTML problem description to clean Markdown. */
+function htmlToMarkdown(html: string): string {
+	const turndown = new TurndownService({
+		headingStyle: "atx",
+		bulletListMarker: "-",
+	});
+
+	let content = turndown.turndown(html);
+
+	// Clean up HTML entities turndown may leave behind
+	content = content
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&#92;/g, "\\")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+
+	return content;
+}

--- a/skills/obsidian/leetcode-obsidian/scripts/lib/obsidian.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/lib/obsidian.ts
@@ -1,0 +1,52 @@
+/**
+ * Obsidian CLI integration.
+ *
+ * Creates notes directly in an Obsidian vault using the CLI:
+ *   https://help.obsidian.md/cli
+ *
+ * Falls back gracefully if the CLI is unavailable.
+ */
+
+import { execSync } from "node:child_process";
+
+/** Check if the Obsidian CLI is available on PATH. */
+export function hasObsidianCli(): boolean {
+	try {
+		execSync("which obsidian", { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Create a note via `obsidian create`.
+ *
+ * @param content  - Note content (markdown)
+ * @param path     - Vault-relative file path
+ * @param vault    - Vault name (optional, uses active vault if empty)
+ * @param openAfter - Open the note in Obsidian after creation
+ * @returns true if creation succeeded
+ */
+export function obsidianCreate(
+	content: string,
+	path: string,
+	vault?: string,
+	openAfter = false,
+): boolean {
+	const args: string[] = ["obsidian"];
+	if (vault) args.push(`vault=${vault}`);
+	args.push("create");
+	args.push(`path=${path}`);
+	args.push(`content=${content}`);
+	args.push("overwrite");
+	if (openAfter) args.push("open");
+
+	try {
+		execSync(args.join(" "), { stdio: "ignore", timeout: 15_000 });
+		return true;
+	} catch (e) {
+		console.warn(`  ⚠️  Obsidian CLI error: ${e}`);
+		return false;
+	}
+}

--- a/skills/obsidian/leetcode-obsidian/scripts/lib/renderer.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/lib/renderer.ts
@@ -1,0 +1,26 @@
+/**
+ * Note renderer.
+ *
+ * Renders an Obsidian markdown note from a Nunjucks/Jinja2 template.
+ * The template receives the question data and full config for
+ * conditional rendering (e.g., toggling hints, solution, complexity).
+ */
+
+import { basename, resolve } from "node:path";
+import nunjucks from "nunjucks";
+import type { Config, Question } from "./types.ts";
+
+/** Render a note from the configured template. */
+export function renderNote(question: Question, cfg: Config): string {
+	const templateDir = resolve(cfg.template, "..");
+	const templateFile = basename(cfg.template);
+
+	const env = new nunjucks.Environment(
+		new nunjucks.FileSystemLoader(templateDir),
+		{ trimBlocks: false, lstripBlocks: false },
+	);
+
+	const now = new Date().toISOString().slice(0, 16); // YYYY-MM-DDTHH:mm
+
+	return env.render(templateFile, { question, now, config: cfg });
+}

--- a/skills/obsidian/leetcode-obsidian/scripts/lib/types.ts
+++ b/skills/obsidian/leetcode-obsidian/scripts/lib/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared type definitions for the LeetCode Obsidian skill.
+ */
+
+/** LeetCode question data returned from the GraphQL API. */
+export interface Question {
+	questionId: string;
+	title: string;
+	titleSlug: string;
+	content: string;
+	difficulty: string;
+	topicTags: { name: string }[];
+	hints: string[];
+	codeSnippets: { lang: string; langSlug: string; code: string }[];
+}
+
+/** Merged configuration from config.toml + CLI args. */
+export interface Config {
+	// settings
+	site: "us" | "cn";
+	downloadImages: boolean;
+	language: string;
+	userAgent: string;
+
+	// paths
+	outputDir: string;
+	imageDir: string;
+	template: string;
+
+	// obsidian
+	obsidianEnabled: boolean;
+	obsidianVault: string;
+	obsidianOpen: boolean;
+
+	// note format
+	filenamePattern: string;
+	platform: string;
+	includeHints: boolean;
+	includeSolution: boolean;
+	includeComplexity: boolean;
+
+	// api
+	graphqlUrl: string;
+	graphqlUrlCn: string;
+}


### PR DESCRIPTION
## Description
New `leetcode-obsidian` skill that fetches LeetCode problems via GraphQL API and generates Obsidian-compatible markdown notes.

## Key Features
- **Modular TypeScript** architecture (6 lib modules + thin CLI)
- **Config-driven** via `config.toml` (API URLs, paths, note format, Obsidian CLI)
- **Obsidian CLI integration** (`obsidian create`) with auto-fallback
- **Nunjucks/Jinja2 template** matching existing Obsidian Templater format
- **Zero local deps** — global Bun packages only

## Files
- `SKILL.md` — skill definition + usage docs
- `config.toml` — all configurable settings
- `scripts/fetch_problem.ts` — CLI entry point
- `scripts/lib/` — types, config, leetcode API, renderer, images, obsidian
- `assets/templates/leetcode_note.md.j2` — note template

## Testing
```
bun scripts/fetch_problem.ts two-sum --output-dir /tmp/test
✅ Generates correct 120-line Obsidian note
```

Closes #21