### PR TITLE
✨ feat(obsidian): add obsidian-icons skill

### DIFF
--- a/skills/obsidian/obsidian-icons/SKILL.md
+++ b/skills/obsidian/obsidian-icons/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: obsidian-icons
+description: "Manage folder and file icons in Obsidian vaults using the Iconize plugin. Use this skill whenever the user mentions folder icons, Iconize, icon packs, icon assignments, or wants to customize how folders/files look in Obsidian's sidebar. Covers: (1) Adding or changing folder/file icons via data.json, (2) Bulk-assigning icons to vault folders, (3) Validating icon names against installed packs, (4) Downloading missing icon SVGs for externally-set icons, (5) Looking up available icon names from Simple Icons, Lucide, Tabler, or other packs. Also trigger when user says 'add icon', 'change icon', 'folder icon', 'SiApple', or any icon pack prefix like Li/Si/Ti/Ri."
+---
+
+# Obsidian Icons (Iconize Plugin)
+
+Manage folder and file icons via the Iconize plugin's `data.json` configuration.
+
+## How Icons Work
+
+The Iconize plugin stores icon assignments in:
+
+```
+.obsidian/plugins/obsidian-icon-folder/data.json
+```
+
+Format: JSON object with a `settings` key and folder/file path → icon ID mappings:
+
+```json
+{
+  "settings": { ... },
+  "Note": "LiNotebookPen",
+  "Note/AI": "TiRobot",
+  "Obsidian": "SiObsidian"
+}
+```
+
+Icon IDs use the format `{PackPrefix}{IconName}` in **PascalCase**.
+
+## Icon Packs
+
+Read `config.toml` for the vault-specific icon pack configuration.
+
+### Naming Convention
+
+| Pack | Prefix | Source | Example |
+|------|--------|--------|---------|
+| Lucide | `Li` | Native/built-in | `LiArchive`, `LiBriefcase` |
+| Simple Icons | `Si` | Brand logos | `SiObsidian`, `SiGoogle` |
+| Tabler Icons | `Ti` | General icons | `TiRobot`, `TiTemplate` |
+| Remix Icons | `Ri` | General icons | `RiBankLine` |
+| Boxicons | `Bo` | General icons | `BoBxGroup` |
+| Font Awesome Solid | `Fas` | General icons | `FasApple` |
+| RPG Awesome | `Ra` | RPG-themed | `RaApple` |
+| Icon Brew | `Ib` | Misc | — |
+| Octicons | `Oc` | GitHub icons | — |
+
+### Priority Order
+
+When choosing icons, prefer in this order:
+
+1. **Simple Icons** (`Si`) — when a brand/product icon exists
+2. **Lucide** (`Li`) — primary generic icons (always available)
+3. **Tabler** (`Ti`) — secondary generic icons
+4. **Remix** (`Ri`) / **Font Awesome** (`Fas`) — tertiary
+5. **Boxicons** (`Bo`) — fallback
+
+Avoid emojis unless explicitly requested.
+
+### Validating Simple Icons Names
+
+Query the Simple Icons source JSON to verify icon names exist:
+
+```bash
+curl -s "https://raw.githubusercontent.com/simple-icons/simple-icons/{VERSION}/_data/simple-icons.json" \
+  | python3 -c "import json,sys; [print(i['title']) for i in json.load(sys.stdin)['icons'] if 'SEARCH' in i['title'].lower()]"
+```
+
+Replace `{VERSION}` with the version from config.toml and `SEARCH` with search term.
+
+## Critical: SVG Caching
+
+**When setting icons via `data.json` externally, the plugin does NOT auto-download SVGs.**
+
+The plugin caches used icon SVGs in `.obsidian/icons/{pack-name}/{IconName}.svg`. Icons set through the Obsidian UI are downloaded automatically, but icons set by editing `data.json` directly will show as raw text (e.g., "SiApple Apple Notes") until the SVG is cached.
+
+### Download Missing SVGs
+
+Run the download script after editing `data.json`:
+
+```bash
+bun run scripts/download_icons.ts [vault-path]
+```
+
+The script reads `data.json`, checks which SVGs are missing from the cache, and downloads them from the correct source repositories.
+
+### Manual Download
+
+Download individual SVGs using the pack source URLs from config.toml:
+
+```bash
+# Simple Icons
+curl -s "https://raw.githubusercontent.com/simple-icons/simple-icons/{VERSION}/icons/{slug}.svg" \
+  -o ".obsidian/icons/simple-icons/{Name}.svg"
+
+# Lucide Icons
+curl -s "https://raw.githubusercontent.com/lucide-icons/lucide/{VERSION}/icons/{slug}.svg" \
+  -o ".obsidian/icons/lucide-icons/{Name}.svg"
+```
+
+**Important:** The SVG filename must be PascalCase (`Apple.svg`), but the download URL uses lowercase slug (`apple.svg`).
+
+## Obsidian Overwrites External Edits
+
+The Iconize plugin writes `data.json` from memory. If Obsidian is running while you edit `data.json`, your changes will be overwritten on next plugin save.
+
+**Workaround:** Either quit Obsidian before editing, or use the download script to also re-apply the data.json after Obsidian closes.
+
+## Workflow: Bulk Icon Assignment
+
+1. Read current `data.json` to see existing assignments
+2. List vault folders (typically top 2 levels)
+3. Choose icons following the priority order
+4. Update `data.json` with new mappings
+5. Run `scripts/download_icons.py` to cache missing SVGs
+6. Reload Obsidian (⌘Q → reopen)
+
+## Workflow: Validate All Icons
+
+1. Read `data.json` icon entries
+2. For each icon, check if the SVG exists in `.obsidian/icons/{pack}/{Name}.svg`
+3. Report missing SVGs
+4. Run `scripts/download_icons.py` to download missing ones

--- a/skills/obsidian/obsidian-icons/config.toml
+++ b/skills/obsidian/obsidian-icons/config.toml
@@ -1,0 +1,42 @@
+# Obsidian Icons Skill Configuration
+
+[vault]
+# Path to the Obsidian vault root
+path = "~/path/to/your/obsidian/vault"
+
+# Relative path to icon data file from vault root
+data_json = ".obsidian/plugins/obsidian-icon-folder/data.json"
+
+# Relative path to icon SVG cache directory from vault root
+icons_dir = ".obsidian/icons"
+
+[packs]
+# Icon pack source URLs and versions
+# Used by download_icons.py to fetch missing SVGs
+
+[packs.simple-icons]
+prefix = "Si"
+version = "11.10.0"
+base_url = "https://raw.githubusercontent.com/simple-icons/simple-icons/{version}/icons/{slug}.svg"
+index_url = "https://raw.githubusercontent.com/simple-icons/simple-icons/{version}/_data/simple-icons.json"
+
+[packs.lucide-icons]
+prefix = "Li"
+version = "0.363.0"
+base_url = "https://raw.githubusercontent.com/lucide-icons/lucide/{version}/icons/{slug}.svg"
+
+[packs.tabler-icons]
+prefix = "Ti"
+version = "3.1.0"
+base_url = "https://raw.githubusercontent.com/tabler/tabler-icons/{version}/icons/outline/{slug}.svg"
+
+[packs.remix-icons]
+prefix = "Ri"
+version = "4.6.0"
+# Remix Icons uses a different structure; manual download may be needed
+base_url = ""
+
+[packs.boxicons]
+prefix = "Bo"
+version = "2.1.4"
+base_url = ""

--- a/skills/obsidian/obsidian-icons/scripts/download_icons.ts
+++ b/skills/obsidian/obsidian-icons/scripts/download_icons.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+/**
+ * Download missing icon SVGs for Obsidian Iconize plugin.
+ *
+ * Reads data.json, checks which icons are missing from the SVG cache,
+ * and downloads them from their respective source repositories.
+ *
+ * Usage: bun run scripts/download_icons.ts [vault-path]
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseToml } from "./utils";
+
+interface PackConfig {
+  prefix: string;
+  version: string;
+  base_url: string;
+  index_url?: string;
+}
+
+interface Config {
+  vault: { path: string; data_json: string; icons_dir: string };
+  packs: Record<string, PackConfig>;
+}
+
+interface MissingIcon {
+  path: string;
+  iconId: string;
+  iconName: string;
+  packName: string;
+  packConfig: PackConfig;
+  svgPath: string;
+}
+
+function loadConfig(skillDir: string): Config {
+  const raw = readFileSync(join(skillDir, "config.toml"), "utf-8");
+  return parseToml(raw) as unknown as Config;
+}
+
+function expandHome(p: string): string {
+  return p.startsWith("~/") ? p.replace("~", Bun.env.HOME ?? "") : p;
+}
+
+/** Convert PascalCase icon name to lowercase slug (e.g., NotebookPen -> notebook-pen) */
+function toSlug(name: string): string {
+  return name
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/([a-zA-Z])(\d)/g, "$1-$2")
+    .toLowerCase();
+}
+
+function findMissingIcons(
+  data: Record<string, unknown>,
+  vaultPath: string,
+  config: Config,
+): MissingIcon[] {
+  const iconsDir = join(vaultPath, config.vault.icons_dir);
+  const packs = config.packs ?? {};
+
+  // Build prefix -> pack mapping (longest prefix first)
+  const prefixMap = new Map<string, [string, PackConfig]>();
+  for (const [packName, packConfig] of Object.entries(packs)) {
+    prefixMap.set(packConfig.prefix, [packName, packConfig]);
+  }
+  const prefixes = [...prefixMap.keys()].sort((a, b) => b.length - a.length);
+
+  const missing: MissingIcon[] = [];
+
+  for (const [path, iconId] of Object.entries(data).sort()) {
+    if (path === "settings" || typeof iconId !== "string") continue;
+
+    for (const prefix of prefixes) {
+      if (iconId.startsWith(prefix)) {
+        const iconName = iconId.slice(prefix.length);
+        const [packName, packConfig] = prefixMap.get(prefix)!;
+        const svgPath = join(iconsDir, packName, `${iconName}.svg`);
+
+        if (!existsSync(svgPath)) {
+          missing.push({ path, iconId, iconName, packName, packConfig, svgPath });
+        }
+        break;
+      }
+    }
+  }
+
+  return missing;
+}
+
+async function downloadIcon(icon: MissingIcon): Promise<boolean> {
+  const { base_url, version } = icon.packConfig;
+  if (!base_url) return false;
+
+  const slugs = [toSlug(icon.iconName), icon.iconName.toLowerCase()];
+  const seen = new Set<string>();
+
+  for (const slug of slugs) {
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+
+    const url = base_url.replace("{version}", version).replace("{slug}", slug);
+
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const svg = await res.text();
+        if (svg.includes("<svg")) {
+          const dir = join(icon.svgPath, "..");
+          mkdirSync(dir, { recursive: true });
+          writeFileSync(icon.svgPath, svg);
+          return true;
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+}
+
+async function main() {
+  const skillDir = resolve(import.meta.dir, "..");
+  const config = loadConfig(skillDir);
+
+  const vaultPath = Bun.argv[2]
+    ? expandHome(Bun.argv[2])
+    : expandHome(config.vault.path);
+
+  if (!existsSync(vaultPath)) {
+    console.error(`✗ Vault not found: ${vaultPath}`);
+    process.exit(1);
+  }
+
+  const dataPath = join(vaultPath, config.vault.data_json);
+  const data = JSON.parse(readFileSync(dataPath, "utf-8"));
+  const missing = findMissingIcons(data, vaultPath, config);
+
+  if (missing.length === 0) {
+    console.log("✓ All icon SVGs are cached");
+    return;
+  }
+
+  console.log(`Found ${missing.length} missing icon(s):\n`);
+
+  let success = 0;
+  const failed: MissingIcon[] = [];
+
+  for (const icon of missing) {
+    process.stdout.write(`  ${icon.iconId} (${icon.packName})... `);
+    if (await downloadIcon(icon)) {
+      console.log("✓");
+      success++;
+    } else {
+      console.log("✗");
+      failed.push(icon);
+    }
+  }
+
+  console.log(`\n${"─".repeat(40)}`);
+  console.log(`Downloaded: ${success}/${missing.length}`);
+
+  if (failed.length > 0) {
+    console.log(`Failed: ${failed.length}`);
+    for (const icon of failed) {
+      console.log(`  - ${icon.iconId} (${icon.path})`);
+    }
+    console.log("\nTip: Set failed icons via Obsidian UI (right-click → Change Icon)");
+  }
+}
+
+main();

--- a/skills/obsidian/obsidian-icons/scripts/utils.ts
+++ b/skills/obsidian/obsidian-icons/scripts/utils.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal TOML parser for simple key-value configs.
+ * Handles sections, strings, numbers, booleans, and arrays.
+ */
+export function parseToml(input: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let currentSection = result;
+  const sectionStack: string[] = [];
+
+  for (const rawLine of input.split("\n")) {
+    const line = rawLine.trim();
+
+    // Skip empty lines and comments
+    if (!line || line.startsWith("#")) continue;
+
+    // Section header [section] or [section.subsection]
+    const sectionMatch = line.match(/^\[(.+)]$/);
+    if (sectionMatch) {
+      const parts = sectionMatch[1].split(".");
+      currentSection = result;
+      sectionStack.length = 0;
+
+      for (const part of parts) {
+        if (!(part in (currentSection as Record<string, unknown>))) {
+          (currentSection as Record<string, unknown>)[part] = {};
+        }
+        currentSection = (currentSection as Record<string, unknown>)[part] as Record<string, unknown>;
+        sectionStack.push(part);
+      }
+      continue;
+    }
+
+    // Key = value
+    const kvMatch = line.match(/^(\w+)\s*=\s*(.+)$/);
+    if (kvMatch) {
+      const [, key, rawValue] = kvMatch;
+      (currentSection as Record<string, unknown>)[key] = parseValue(rawValue.trim());
+    }
+  }
+
+  return result;
+}
+
+function parseValue(raw: string): unknown {
+  // String (double or single quoted)
+  const strMatch = raw.match(/^["'](.*)["']$/);
+  if (strMatch) return strMatch[1];
+
+  // Boolean
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+
+  // Array
+  if (raw.startsWith("[")) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(",").map((s) => parseValue(s.trim()));
+  }
+
+  // Number
+  const num = Number(raw);
+  if (!Number.isNaN(num)) return num;
+
+  return raw;
+}


### PR DESCRIPTION
Add skill for managing Obsidian folder/file icons via the Iconize plugin.

## Changes
- **SKILL.md**: Icon pack naming conventions, SVG caching, validation & bulk assignment workflows
- **config.toml**: Pack versions and download URLs (no private paths)
- **scripts/download_icons.ts**: Bun/TS script to auto-download missing icon SVGs
- **scripts/utils.ts**: Minimal TOML parser

Closes #23